### PR TITLE
fix(demo-app): 在庫切れ商品で TypeError 修正 (INC001, TrackID:0DFD5E8)

### DIFF
--- a/projects/log_collector/demo-app/bug-config.json
+++ b/projects/log_collector/demo-app/bug-config.json
@@ -1,0 +1,18 @@
+{
+  "bugs": {
+    "PRODUCT_STOCK_ZERO_NPE": {
+      "enabled": false,
+      "description": "GET /api/robots/:sku で stock=0 の商品を見ると related_products を undefined で map しようとして TypeError",
+      "affects": "src/routes/products.js#getProduct",
+      "trigger": "SKU RBT-DOG-02 (stock=0) の詳細ページを開く",
+      "user_impact": "在庫切れ商品ページが 500 になり離脱率上昇"
+    },
+    "ORDER_TOTAL_UNDEFINED_TAX": {
+      "enabled": true,
+      "description": "POST /api/orders で payment_method='invoice' のとき tax_rate が未定義になり total.toFixed() で TypeError",
+      "affects": "src/routes/orders.js#calcTotal",
+      "trigger": "決済方法「請求書払い」で注文確定",
+      "user_impact": "法人向け請求書決済が全滅、機会損失甚大"
+    }
+  }
+}

--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { isEnabled } = require('../lib/bug-switch');
+
+const router = express.Router();
+
+const DATA_PATH = path.join(__dirname, '..', '..', 'data', 'robots.json');
+
+function loadRobots() {
+  return JSON.parse(fs.readFileSync(DATA_PATH, 'utf8'));
+}
+
+router.get('/', (req, res) => {
+  const robots = loadRobots();
+  res.json(robots.map(r => ({
+    sku: r.sku, name: r.name, price: r.price, stock: r.stock, category: r.category,
+  })));
+});
+
+router.get('/:sku', (req, res, next) => {
+  try {
+    const robots = loadRobots();
+    const robot = robots.find(r => r.sku === req.params.sku);
+    if (!robot) return res.status(404).json({ error: 'robot not found' });
+
+    const relatedList = robot.related || [];
+
+    const related = relatedList.map(sku => {
+      const r = robots.find(x => x.sku === sku);
+      return r ? { sku: r.sku, name: r.name, price: r.price } : null;
+    }).filter(Boolean);
+
+    res.json({ ...robot, related_products: related });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary

修正内容: インシデント INC001 - 在庫切れ商品の詳細ページで TypeError が発生する問題を修正

- **エンドポイント**: `GET /api/robots/:sku` (在庫切れ商品のみ)
- **エラー**: `TypeError: Cannot read properties of undefined (reading 'map')`
- **影響商品**: RBT-DOG-02 (stock=0)
- **TrackID**: 0DFD5E8

### 変更内容

1. **src/routes/products.js**: バグロジックの削除
   - 在庫の有無に関わらず常に `robot.related || []` を使用
   - 未定義の `out_of_stock_alternatives` プロパティへのアクセスを排除

2. **bug-config.json**: バグスイッチの無効化
   - `PRODUCT_STOCK_ZERO_NPE.enabled` を `false` に変更

## 一次解析結果 (by incident-analyzer)

【症状】
GET /api/robots/RBT-DOG-02 が HTTP 500 を返し、TypeError: Cannot read properties of undefined (reading 'map') が発生しています。
エラー発生箇所: src/routes/products.js:34:33
TrackID: 0DFD5E8
タイムスタンプ: 2026-07-17T22:10:42.321Z
在庫切れ商品 (stock=0) の詳細ページで常に発生します。

【原因仮説】
(信頼度: 高) src/routes/products.js の 28-34 行目において、バグスイッチ PRODUCT_STOCK_ZERO_NPE が有効な状態で、robot.stock === 0 の分岐に入ると、robot.out_of_stock_alternatives プロパティを relatedList に代入します。しかし RBT-DOG-02 のデータ (data/robots.json) には out_of_stock_alternatives プロパティが定義されておらず、undefined が relatedList に代入されます。その結果 34 行目で relatedList.map() を実行する際に TypeError が発生します。

(信頼度: 中) bug-config.json で PRODUCT_STOCK_ZERO_NPE.enabled = true に設定されているため、意図的に埋め込まれたバグが発火しています。この設定を false にすることで即座に解決可能です。

【影響範囲】
影響エンドポイント: GET /api/robots/:sku (在庫切れ商品のみ)
現在影響を受ける商品: RBT-DOG-02 (stock=0)
他機能への波及: 商品一覧 API (/api/robots)、カート機能 (/api/cart)、注文機能 (/api/orders) は影響なし
ユーザー影響: 在庫切れ商品の詳細ページを閲覧した顧客が 500 エラーに遭遇し、関連商品の確認ができず離脱率が上昇します。

【再現手順】
1. ブラウザまたは curl で以下にアクセス:
   curl http://ec2-54-88-196-71.compute-1.amazonaws.com:3002/api/robots/RBT-DOG-02
   (ローカル環境: curl http://localhost:3002/api/robots/RBT-DOG-02)
2. HTTP 500 レスポンスと TypeError のエラーメッセージが返されることを確認
3. logs/app.log に ERROR 行が記録され、TrackID と共にスタックトレース (src/routes/products.js:34:33) が出力されます

## 改修案 (by repair-planner)

【対象ファイル】
- projects/log_collector/demo-app/src/routes/products.js
- projects/log_collector/demo-app/bug-config.json

【変更方針】

**1. バグロジックの削除 (src/routes/products.js)**

```diff
-    let relatedList;
-    if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
-    } else {
-      relatedList = robot.related || [];
-    }
+    const relatedList = robot.related || [];
```

**2. バグスイッチの無効化 (bug-config.json)**

```diff
     "PRODUCT_STOCK_ZERO_NPE": {
-      "enabled": true,
+      "enabled": false,
```

**修正方針の説明:**
- 28-32 行目の条件分岐を削除し、在庫の有無に関わらず常に `robot.related || []` を使用
- 未定義プロパティへのアクセスを排除し、デフォルト値 `[]` でフォールバック
- バグスイッチ PRODUCT_STOCK_ZERO_NPE を無効化してバグロジックの発火を防止

## 承認者

於保げ

## Test plan

- [ ] RBT-DOG-02 (stock=0) の詳細ページにアクセスして HTTP 200 が返ることを確認
- [ ] related_products が配列型で返されることを確認
- [ ] TypeError が発生しないことをログで確認
- [ ] 在庫あり商品 (RBT-ARM-01 等) で正常に related_products が返されることを確認
- [ ] related プロパティが未定義の商品でも空配列が返されることを確認
- [ ] 存在しない SKU では HTTP 404 が返されることを確認

## Related

Closes #22 (AI 自動改修デモ - インシデント INC001)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
