### PR TITLE
fix(demo-app): 在庫切れ商品で TypeError が発生する問題を修正 (INC001, TrackID:40F65E3)

### DIFF
--- a/projects/log_collector/demo-app/bug-config.json
+++ b/projects/log_collector/demo-app/bug-config.json
@@ -1,0 +1,18 @@
+{
+  "bugs": {
+    "PRODUCT_STOCK_ZERO_NPE": {
+      "enabled": false,
+      "description": "GET /api/robots/:sku で stock=0 の商品を見ると related_products を undefined で map しようとして TypeError",
+      "affects": "src/routes/products.js#getProduct",
+      "trigger": "SKU RBT-DOG-02 (stock=0) の詳細ページを開く",
+      "user_impact": "在庫切れ商品ページが 500 になり離脱率上昇"
+    },
+    "ORDER_TOTAL_UNDEFINED_TAX": {
+      "enabled": true,
+      "description": "POST /api/orders で payment_method='invoice' のとき tax_rate が未定義になり total.toFixed() で TypeError",
+      "affects": "src/routes/orders.js#calcTotal",
+      "trigger": "決済方法「請求書払い」で注文確定",
+      "user_impact": "法人向け請求書決済が全滅、機会損失甚大"
+    }
+  }
+}

--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { isEnabled } = require('../lib/bug-switch');
+
+const router = express.Router();
+
+const DATA_PATH = path.join(__dirname, '..', '..', 'data', 'robots.json');
+
+function loadRobots() {
+  return JSON.parse(fs.readFileSync(DATA_PATH, 'utf8'));
+}
+
+router.get('/', (req, res) => {
+  const robots = loadRobots();
+  res.json(robots.map(r => ({
+    sku: r.sku, name: r.name, price: r.price, stock: r.stock, category: r.category,
+  })));
+});
+
+router.get('/:sku', (req, res, next) => {
+  try {
+    const robots = loadRobots();
+    const robot = robots.find(r => r.sku === req.params.sku);
+    if (!robot) return res.status(404).json({ error: 'robot not found' });
+
+    const relatedList = robot.related || [];
+
+    const related = relatedList.map(sku => {
+      const r = robots.find(x => x.sku === sku);
+      return r ? { sku: r.sku, name: r.name, price: r.price } : null;
+    }).filter(Boolean);
+
+    res.json({ ...robot, related_products: related });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary

GET /api/robots/RBT-DOG-02 (在庫切れ商品) のアクセス時に HTTP 500 エラー (`TypeError: Cannot read properties of undefined (reading 'map')`) が発生する問題を修正しました。

**関連 Issue**: #22 (AI 自動改修デモ)

**インシデント**: INC001  
**TrackID**: 40F65E3  
**承認者**: ほげ

---

## 一次解析結果

【症状】GET /api/robots/RBT-DOG-02 が HTTP 500 を返し、「TypeError: Cannot read properties of undefined (reading 'map')」が発生している。TrackID:40F65E3 で記録されている。

【原因仮説】(信頼度:高) src/routes/products.js の line 28-29 にて、バグスイッチ PRODUCT_STOCK_ZERO_NPE が有効 (bug-config.json line 4) な場合、在庫切れ商品 (stock=0) に対して robot.out_of_stock_alternatives プロパティを参照しようとするが、このプロパティは robots.json の RBT-DOG-02 に存在しない (line 12-19 に out_of_stock_alternatives フィールドなし)。その結果、line 29 で relatedList が undefined となり、line 34 で undefined.map() を実行してエラーが発生する。

【影響範囲】在庫切れ商品 (RBT-DOG-02) の詳細ページ全体が 500 エラーで閲覧不可。商品一覧 API (/api/robots)、カート機能 (/api/cart)、注文機能 (/api/orders) への波及はなし。ユーザー影響: 在庫切れ商品を見ようとした顧客が 500 エラー画面で離脱し、関連商品 (代替製品) の提案機会を喪失。

【再現手順】
1. curl http://localhost:3002/api/robots/RBT-DOG-02 を実行
2. または Web ブラウザで http://localhost:3002/product/RBT-DOG-02 を開く
3. HTTP 500 エラーが返され、logs/app.log に「ERROR TrackID:XXXXXXX [/api/robots/RBT-DOG-02] method=GET status=500 err=TypeError: Cannot read properties of undefined (reading 'map')」が記録される

---

## 改修案

### 対象ファイル
`projects/log_collector/demo-app/src/routes/products.js`

### 変更方針
バグスイッチ PRODUCT_STOCK_ZERO_NPE によって挿入された、存在しないプロパティを参照するロジック (line 28-29) を削除し、常に robot.related (デフォルト空配列) を使用するよう修正します。

### 変更内容

```diff
--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -25,11 +25,7 @@ router.get('/:sku', (req, res, next) => {
     if (!robot) return res.status(404).json({ error: 'robot not found' });
 
-    let relatedList;
-    if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
-    } else {
-      relatedList = robot.related || [];
-    }
+    const relatedList = robot.related || [];
 
     const related = relatedList.map(sku => {
       const r = robots.find(x => x.sku === sku);
```

修正内容:
- line 27-32 の条件分岐を削除
- line 27 を `const relatedList = robot.related || [];` に置き換え
- robots.json に実際に存在する related プロパティを使用し、存在しない場合は空配列をフォールバック

### 効果
- 在庫切れ商品 RBT-DOG-02 の詳細ページが正常に表示されるようになります
- related_products は ["RBT-CAT-03"] として正常に返されます
- bug-config.json の PRODUCT_STOCK_ZERO_NPE バグスイッチは無効化されます (条件分岐自体が削除されるため)

---

## Test plan
- [x] RBT-DOG-02 (在庫切れ) の詳細ページが HTTP 200 を返すことを確認
- [x] related_products に ["RBT-CAT-03"] が含まれることを確認
- [x] 在庫あり商品 (RBT-ARM-01 など) の動作に影響がないことを確認
- [x] 商品一覧 API (/api/robots) が正常動作することを確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)