### PR TITLE
fix(demo-app): stock=0商品のTypeError修正 (INC001, TrackID:714A606)

### DIFF
--- a/projects/log_collector/demo-app/.demo-templates/src/routes/products.js
+++ b/projects/log_collector/demo-app/.demo-templates/src/routes/products.js
@@ -26,7 +26,7 @@ router.get('/:sku', (req, res, next) => {
 
     let relatedList;
     if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
+      relatedList = robot.out_of_stock_alternatives || [];
     } else {
       relatedList = robot.related || [];
     }

--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -26,7 +26,7 @@ router.get('/:sku', (req, res, next) => {
 
     let relatedList;
     if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
+      relatedList = robot.out_of_stock_alternatives || [];
     } else {
       relatedList = robot.related || [];
     }


### PR DESCRIPTION
## 概要

Issue #22 自動改修デモに基づく修正です。

`GET /api/robots/RBT-DOG-02` が HTTP 500 (`TypeError: Cannot read properties of undefined (reading 'map')`) を返す不具合を修正します。

- **インシデントID**: INC001
- **TrackID**: 714A606
- **承認者**: ほげ

## 一次解析結果 (analysis)

【症状】GET /api/robots/RBT-DOG-02 が HTTP 500 を返し、TypeError: Cannot read properties of undefined (reading 'map') が発生 (products.js:34:33)。アプリログ(logs/app.log)にも TrackID:714A606 で同エラーが記録済み。

【原因仮説】
- (信頼度:高) src/routes/products.js の GET /:sku ハンドラで stock=0 かつ bug-config.json の PRODUCT_STOCK_ZERO_NPE フラグが有効な場合、relatedList = robot.out_of_stock_alternatives を参照するが、data/robots.json の RBT-DOG-02 エントリには out_of_stock_alternatives フィールドが存在せず undefined のまま .map() が呼ばれてクラッシュする。
- (信頼度:中) bug-config.json 自体がこのバグをデモ用に意図的に有効化している設定ミス/未実装機能である可能性。
- (信頼度:低) 将来的に他の stock=0 商品が追加された際にも同フィールド未定義であれば同様に発生する構造的リスク。

【影響範囲】現状 stock=0 の商品は RBT-DOG-02 のみのため /api/robots/RBT-DOG-02 (および対応する /product/RBT-DOG-02 ページ) が 500 エラーになる。/api/robots (一覧) は related_products を組み立てないため影響なし。カート・注文機能への直接波及は無いが、商品詳細取得に失敗するためユーザーはその商品をカートに追加する前段階で離脱する。

【再現手順】
1. `curl http://localhost:3002/api/robots/RBT-DOG-02` → 500 エラーとTypeErrorのJSONが返ることを確認。
2. ブラウザで http://localhost:3002/product/RBT-DOG-02 を開いても同様にAPI呼び出しが失敗する。

## 改修案 (repair_plan)

【対象ファイル】
- `projects/log_collector/demo-app/src/routes/products.js`
- `projects/log_collector/demo-app/.demo-templates/src/routes/products.js` (デモリセット時に復元される同一バグのテンプレート。本番修正と同時に揃える必要あり)

【変更方針】
TrackID:714A606 で捕捉した TypeError の原因は、robot.stock===0 かつ PRODUCT_STOCK_ZERO_NPE フラグ有効時に relatedList = robot.out_of_stock_alternatives を参照するが、data/robots.json の RBT-DOG-02 エントリに out_of_stock_alternatives フィールドが存在せず undefined になること。undefined.map() でクラッシュしないよう、フォールバックで空配列を保証する。

```diff
--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -25,9 +25,9 @@ router.get('/:sku', (req, res, next) => {
     let relatedList;
     if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
+      relatedList = robot.out_of_stock_alternatives || [];
     } else {
       relatedList = robot.related || [];
     }
```

同内容を `.demo-templates/src/routes/products.js` にも同様に適用し、デモリセット (POST /api/reset) 後も再発しないようにしました。

【追加テスト (今後の対応案)】
- `test/routes/products.test.js` (新規作成候補)
  - stock=0 かつ PRODUCT_STOCK_ZERO_NPE 有効時、out_of_stock_alternatives 未定義でも 200 と空の related_products を返す (今回の500エラーの回帰防止)
  - stock=0 かつ out_of_stock_alternatives が定義されている場合、そのSKUを related_products に解決して返す
  - stock>0 の通常商品では従来通り related フィールドから related_products を返す
  - 存在しないSKUでは404を返す

※ 本PRでは `demo-app` に `npm test` スクリプトが定義されていないため、テストは未追加/未実行です。

【ロールバック】
`git revert <このPRのコミットSHA>`
ロールバック後は PRODUCT_STOCK_ZERO_NPE の挙動が元(バグあり)に戻るため、bug-config.json 側で該当フラグを一時的に false にする運用回避も可能。

## 承認情報

- 承認者: ほげ
- 関連Issue: #22

---
🤖 Generated with Claude Code
