### PR TITLE
fix(demo-app): stock=0商品のTypeError修正 (INC001, TrackID:6FA3C7A)

### DIFF
--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -26,7 +26,7 @@ router.get('/:sku', (req, res, next) => {
 
     let relatedList;
     if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
+      relatedList = robot.out_of_stock_alternatives || robot.related || [];
     } else {
       relatedList = robot.related || [];
     }


### PR DESCRIPTION
## 概要
Issue #22 自動改修デモ対応。INC001 (TrackID:6FA3C7A) の修正 PR です。

**承認者**: ほげ

## 一次解析結果
GET /api/robots/RBT-DOG-02 (stock=0) が HTTP 500 を返し、`TypeError: Cannot read properties of undefined (reading 'map')` が発生。

原因: `src/routes/products.js` の GET /:sku ハンドラで、`bug-config.json` の `PRODUCT_STOCK_ZERO_NPE` フラグが有効な場合、stock===0 商品では `robot.out_of_stock_alternatives` を参照するが、`data/robots.json` の RBT-DOG-02 レコードにこのプロパティが存在せず `undefined.map()` で例外が発生していた。

影響範囲: stock=0 の商品詳細ページ全て(現状データ上は RBT-DOG-02 のみ)。

## 改修案
`relatedList` に `out_of_stock_alternatives` が未定義の場合のフォールバック (`robot.related || []`) を追加し、undefined に対する `.map()` 呼び出しを防止しました。

```diff
-      relatedList = robot.out_of_stock_alternatives;
+      relatedList = robot.out_of_stock_alternatives || robot.related || [];
```

対象ファイル: `projects/log_collector/demo-app/src/routes/products.js`

## TrackID
TrackID:6FA3C7A

---
🤖 Generated with Claude Code
