### PR TITLE
fix(demo-app): stock=0商品でTypeError発生を修正 (INC001, TrackID:563804F)

### DIFF
--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -26,7 +26,7 @@ router.get('/:sku', (req, res, next) => {
 
     let relatedList;
     if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
+      relatedList = robot.out_of_stock_alternatives || robot.related || [];
     } else {
       relatedList = robot.related || [];
     }


### PR DESCRIPTION
## 概要
Issue #22 自動改修デモ。GET /api/robots/RBT-DOG-02 で発生していた TypeError を修正 (INC001, TrackID:563804F)。

## 一次解析結果
GET /api/robots/:sku が HTTP 500 を返し、`TypeError: Cannot read properties of undefined (reading 'map')` が発生 (TrackID:563804F)。
原因は src/routes/products.js の GET /api/robots/:sku 内で、stock===0 かつ機能フラグ `PRODUCT_STOCK_ZERO_NPE` (bug-config.json で enabled:true) の場合、`robot.out_of_stock_alternatives` を related 商品リストとして使用するが、data/robots.json の RBT-DOG-02 (stock:0) にはこのフィールドが存在せず undefined となり、続く `.map()` 呼び出しで TypeError が発生していた。

## 改修案
`relatedList = robot.out_of_stock_alternatives;` を `relatedList = robot.out_of_stock_alternatives || robot.related || [];` に変更し、フィールド未定義時に安全にフォールバックするよう修正。
data/robots.json / bug-config.json はデモ用の障害注入設定のため変更せず、アプリ側の防御的実装のみで対応。

## 承認者
ほげ

## TrackID
563804F

---
🤖 Generated with Claude Code
