### PR TITLE
fix(demo-app): stock=0時のTypeError修正 (INC001, TrackID:F4EDD34)

### DIFF
--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -26,7 +26,7 @@ router.get('/:sku', (req, res, next) => {
 
     let relatedList;
     if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
+      relatedList = robot.out_of_stock_alternatives || robot.related || [];
     } else {
       relatedList = robot.related || [];
     }


### PR DESCRIPTION
## 概要

Issue #22 自動改修デモ対応。INC001 (TrackID:F4EDD34) に対する修正PRです。

## 一次解析結果

【症状】GET /api/robots/RBT-DOG-02 で HTTP 500 が発生し、TypeError: Cannot read properties of undefined (reading 'map') が発生している。(TrackID:F4EDD34)

【原因仮説】(信頼度:高) src/routes/products.js の router.get('/:sku') 内で、robot.stock===0 かつ bug-config.json の PRODUCT_STOCK_ZERO_NPE が enabled のため relatedList = robot.out_of_stock_alternatives を参照するが、data/robots.json の RBT-DOG-02 エントリには out_of_stock_alternatives フィールドが存在せず undefined となり、続く relatedList.map() で TypeError が発生している。

【影響範囲】stock=0 の在庫切れ商品全般 (現状確認できているのは RBT-DOG-02)。

## 改修内容

`src/routes/products.js` の `relatedList` 取得部分にフォールバックを追加し、`out_of_stock_alternatives` が未定義でも安全に動作するように修正しました。

```diff
-      relatedList = robot.out_of_stock_alternatives;
+      relatedList = robot.out_of_stock_alternatives || robot.related || [];
```

## 承認者

hoge

## TrackID

F4EDD34

---
🤖 Generated with Claude Code
