### PR TITLE
fix(demo-app): stock=0時のrelated_products取得TypeErrorを修正 (INC001, TrackID:E09B815)

### DIFF
--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -1,8 +1,6 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
-const { isEnabled } = require('../lib/bug-switch');
-
 const router = express.Router();
 
 const DATA_PATH = path.join(__dirname, '..', '..', 'data', 'robots.json');
@@ -24,12 +22,7 @@ router.get('/:sku', (req, res, next) => {
     const robot = robots.find(r => r.sku === req.params.sku);
     if (!robot) return res.status(404).json({ error: 'robot not found' });
 
-    let relatedList;
-    if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
-    } else {
-      relatedList = robot.related || [];
-    }
+    const relatedList = robot.related || [];
 
     const related = relatedList.map(sku => {
       const r = robots.find(x => x.sku === sku);


### PR DESCRIPTION
## 概要

Issue #22 自動改修デモ対応。INC001 (TrackID:E09B815) の一次解析・改修案に基づき、`/api/robots/:sku` の TypeError を修正。

## 一次解析結果

【症状】GET /api/robots/RBT-DOG-02 が HTTP 500 を返し、TypeError: Cannot read properties of undefined (reading 'map') が発生 (TrackID:E09B815)。src/routes/products.js:34:33 で例外。

【原因仮説】(信頼度:高) src/routes/products.js の GET /:sku ハンドラで、stock===0 かつ bug-switch 'PRODUCT_STOCK_ZERO_NPE' が有効な場合、relatedList = robot.out_of_stock_alternatives を参照するが、data/robots.json 内の RBT-DOG-02 (stock:0) には out_of_stock_alternatives フィールドが存在せず undefined となり、直後の .map() 呼び出しで例外化している。

## 改修内容

- `src/routes/products.js` の分岐を撤廃し、常に `robot.related || []` を使用するよう修正
- 未使用となった `isEnabled` の import を削除

## 承認者

hoge

## その他

- TrackID: E09B815
- Issue #22 (自動改修デモ) 関連

🤖 Generated with Claude Code
