### PR TITLE
fix(demo-app): stock=0商品のTypeError修正 (INC001, TrackID:15435F9)

### DIFF
--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -26,9 +26,11 @@ router.get('/:sku', (req, res, next) => {
 
     let relatedList;
     if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
+      relatedList = Array.isArray(robot.out_of_stock_alternatives)
+        ? robot.out_of_stock_alternatives
+        : [];
     } else {
-      relatedList = robot.related || [];
+      relatedList = Array.isArray(robot.related) ? robot.related : [];
     }
 
     const related = relatedList.map(sku => {


### PR DESCRIPTION
## 概要
Issue #22 自動改修デモ (INC001, TrackID:15435F9)

`GET /api/robots/RBT-DOG-02` (stock=0) が `TypeError: Cannot read properties of undefined (reading 'map')` で HTTP 500 を返す不具合を修正します。

## 一次解析結果
GET /api/robots/RBT-DOG-02 (stock=0の商品) がHTTP 500を返し、TypeError: Cannot read properties of undefined (reading 'map') が発生。app.log上でTrackID:15435F9のリクエストが method=GET status=500、発生箇所は src/routes/products.js:34 (relatedList.map(...))。

原因: bug-config.json の PRODUCT_STOCK_ZERO_NPE フラグ有効時、products.js の GET /:sku ハンドラでは stock===0 の場合 relatedList = robot.out_of_stock_alternatives を使うが、data/robots.json の RBT-DOG-02 エントリにはこのフィールドが存在せず undefined となり、直後の .map() 呼び出しで例外が発生していた。

影響範囲: GET /api/robots/:sku のうち stock=0 の商品全て。一覧APIやカート・注文機能への直接波及なし。

## 改修内容
`src/routes/products.js` にて `out_of_stock_alternatives` / `related` が配列でない場合に空配列へフォールバックする防御コードを追加。

```diff
-    let relatedList;
-    if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
-    } else {
-      relatedList = robot.related || [];
-    }
+    let relatedList;
+    if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
+      relatedList = Array.isArray(robot.out_of_stock_alternatives)
+        ? robot.out_of_stock_alternatives
+        : [];
+    } else {
+      relatedList = Array.isArray(robot.related) ? robot.related : [];
+    }
```

bug-config.json の `PRODUCT_STOCK_ZERO_NPE.enabled=true` はデモ再現用フラグのため変更していません。

## 承認者
hoge

## TrackID
15435F9

---
🤖 Generated with Claude Code
