### PR TITLE
fix(demo-app): stock=0商品詳細のTypeError修正 (INC001, TrackID:09A1399)

### DIFF
--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -25,11 +25,7 @@ router.get('/:sku', (req, res, next) => {
     if (!robot) return res.status(404).json({ error: 'robot not found' });
 
     let relatedList;
-    if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
-    } else {
-      relatedList = robot.related || [];
-    }
+    relatedList = robot.related || [];
 
     const related = relatedList.map(sku => {
       const r = robots.find(x => x.sku === sku);


### PR DESCRIPTION
## 概要

Issue #22 自動改修デモ対応。

インシデント **INC001** (TrackID: `09A1399`) への修正PRです。

`GET /api/robots/RBT-DOG-02` で HTTP 500 (`TypeError: Cannot read properties of undefined (reading 'map')`) が発生していました。

## 一次解析結果

【症状】GET /api/robots/RBT-DOG-02 へのアクセスで HTTP 500 が発生し、TypeError: Cannot read properties of undefined (reading 'map') が発生している (TrackID:09A1399)。ログサーバから該当ログは収集できず (exit 1, ログ0件)、ソース解析のみで原因を特定。

【原因仮説】(信頼度:高) src/routes/products.js の GET /:sku ハンドラで、stock===0 かつバグフラグ PRODUCT_STOCK_ZERO_NPE 有効時に relatedList = robot.out_of_stock_alternatives を参照するが、data/robots.json の RBT-DOG-02 (stock=0) には out_of_stock_alternatives フィールドが存在せず undefined となり、直後の relatedList.map() 呼び出しで例外が発生する。

【影響範囲】stock=0 の商品全て (現状 RBT-DOG-02) の詳細ページ GET /api/robots/:sku が影響を受け 500 エラーとなる。一覧 GET /api/robots/ やカート・注文APIには波及しない。

## 改修案

【対象ファイル】projects/log_collector/demo-app/src/routes/products.js

バグフラグ PRODUCT_STOCK_ZERO_NPE が有効な場合、stock=0 の商品では存在しないフィールド `robot.out_of_stock_alternatives` を参照しており、これが undefined のため直後の `.map()` で TypeError となっていました (TrackID: 09A1399)。in-stock 時と同様に `robot.related` (存在しない場合は空配列) を使うよう修正し、存在しないフィールドに依存しないようにしました。

```diff
-    let relatedList;
-    if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
-    } else {
-      relatedList = robot.related || [];
-    }
+    let relatedList;
+    relatedList = robot.related || [];
```

## 承認者

ほげ

## TrackID

09A1399

---

🤖 Generated with Claude Code
