### PR TITLE
fix(demo-app): stock=0商品のTypeError修正 (INC001, TrackID:DF2A7CC)

### DIFF
--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -26,7 +26,7 @@ router.get('/:sku', (req, res, next) => {
 
     let relatedList;
     if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
+      relatedList = robot.out_of_stock_alternatives || robot.related || [];
     } else {
       relatedList = robot.related || [];
     }


### PR DESCRIPTION
## 概要

Issue #22 自動改修デモ対応。

`GET /api/robots/RBT-DOG-02` にて HTTP 500 (TypeError: Cannot read properties of undefined (reading 'map')) が発生していた問題を修正します。

- インシデントID: INC001
- TrackID: DF2A7CC
- 承認者: ほげ

## 一次解析結果

【症状】GET /api/robots/RBT-DOG-02 がHTTP 500を返却。アプリ層(app.log)・サービス層(service.log/inventory-service)双方でTypeError: Cannot read properties of undefined (reading 'map') が発生 (products.js:37)。TrackID:DF2A7CCで両ログが紐づく。

【原因仮説】(信頼度:高) src/routes/products.js内、bug-switch.jsのフラグ PRODUCT_STOCK_ZERO_NPE が有効な場合、stock===0商品では related の代わりに robot.out_of_stock_alternatives を参照するが、data/robots.json内のRBT-DOG-02にはこのフィールドが定義されておらずundefinedとなり、続く.map()呼び出しで例外が発生している。

【影響範囲】/api/robots/:sku のうちstock=0で在庫切れの商品。一覧API・カート・注文機能への波及なし。

## 改修内容

`src/routes/products.js` にて、`robot.out_of_stock_alternatives` が未定義の場合に `robot.related || []` へフォールバックするように修正しました。

```diff
-      relatedList = robot.out_of_stock_alternatives;
+      relatedList = robot.out_of_stock_alternatives || robot.related || [];
```

備考: 恒久対応候補として bug-config.json の `PRODUCT_STOCK_ZERO_NPE.enabled` を false にする、または本分岐自体を削除して常に `robot.related || []` を使う方式も検討可能です。

## テスト

`demo-app` に実行可能な `npm test` スクリプトが定義されていないため、今回はテスト実行をスキップしました。追加テストケース案は解析結果（repair_plan）に記載の通りです。

---
🤖 Generated with Claude Code
