### PR TITLE
fix(demo-app): products.js TypeError修正 (INC001, TrackID:7B0FD69)

### DIFF
--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
-const { isEnabled } = require('../lib/bug-switch');
 
 const router = express.Router();
 
@@ -24,12 +23,9 @@ router.get('/:sku', (req, res, next) => {
     const robot = robots.find(r => r.sku === req.params.sku);
     if (!robot) return res.status(404).json({ error: 'robot not found' });
 
-    let relatedList;
-    if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
-    } else {
-      relatedList = robot.related || [];
-    }
+    // stock=0 でも robot.related を使う。out_of_stock_alternatives は
+    // data/robots.json に存在しないフィールドで未定義参照によりTypeErrorを起こしていた(TrackID:7B0FD69)。
+    const relatedList = Array.isArray(robot.related) ? robot.related : [];
 
     const related = relatedList.map(sku => {
       const r = robots.find(x => x.sku === sku);


### PR DESCRIPTION
## 概要

Issue #22 自動改修デモ対応。INC001 (TrackID:7B0FD69) の自動修正PRです。

`GET /api/robots/RBT-DOG-02` が HTTP 500 (`TypeError: Cannot read properties of undefined (reading 'map')`) を返す不具合を修正しました。

## 一次解析結果 (analysis)

【症状】GET /api/robots/RBT-DOG-02 が HTTP 500 を返し、TypeError: Cannot read properties of undefined (reading 'map') が発生している(TrackID:7B0FD69)。app.log/service.log(inventory-service)双方に同一TrackIDでエラーが記録されており、products.js:37:33 のスタックトレースが確認できる。

【原因仮説】(信頼度:高) src/routes/products.js の /:sku ハンドラで、stock===0 かつ bug-config.json のフラグ PRODUCT_STOCK_ZERO_NPE が有効な場合、relatedList に robot.out_of_stock_alternatives を代入するが、data/robots.json のRBT-DOG-02エントリにこのフィールドが存在しないため undefined となり、続く .map() 呼び出しで TypeError が発生する。

【影響範囲】stock=0 の在庫切れ商品の詳細取得エンドポイント GET /api/robots/:sku 全般。一覧取得(GET /api/robots/)には影響なし。

## 改修案 (repair_plan)

`src/routes/products.js` の relatedList 分岐(bug-config.json の PRODUCT_STOCK_ZERO_NPE フラグによる切替)を撤廃し、常に `robot.related` を使うように変更。配列でない場合は空配列にフォールバックする防御コードを追加。未使用となった `bug-switch` の import も削除。

## 承認者

ほげ

## TrackID

7B0FD69

---

🤖 Generated with Claude Code
