### PR TITLE
fix(demo-app): stock=0商品でNPEが発生する不具合を修正 (INC001, TrackID:736C4C7)

### DIFF
--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -29,7 +29,7 @@ router.get('/:sku', (req, res, next) => {
 
     let relatedList;
     if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
+      relatedList = robot.out_of_stock_alternatives || [];
     } else {
       relatedList = robot.related || [];
     }


### PR DESCRIPTION
Issue #22 自動改修デモ対応 (INC001, TrackID:736C4C7)

## 一次解析結果
GET /api/robots/RBT-DOG-02 がHTTP 500を返す。app.log/service.log双方(TrackID:736C4C7)にTypeError: Cannot read properties of undefined (reading 'map') が記録され、demo-app/src/routes/products.js:37で発生。

原因: `src/routes/products.js` の `/:sku` ハンドラで、`robot.stock===0` かつ bug-switch の `PRODUCT_STOCK_ZERO_NPE` フラグが有効な場合、`relatedList` に `robot.out_of_stock_alternatives` を代入しているが、`data/robots.json` の RBT-DOG-02 には `out_of_stock_alternatives` フィールドが存在せず `undefined` となり、続く `.map()` 呼び出しで例外が発生していた。

## 改修案
`relatedList = robot.out_of_stock_alternatives;` を `relatedList = robot.out_of_stock_alternatives || [];` に変更し、未定義でも安全にフォールバックするよう修正。

## 承認者
ほげ

## その他
- TrackID: 736C4C7
- 対象ファイル: `projects/log_collector/demo-app/src/routes/products.js`

🤖 Generated with Claude Code
