### PR TITLE
fix(demo-app): stock=0商品詳細のTypeError修正 (INC001, TrackID:9AD1511)

### DIFF
--- a/projects/log_collector/demo-app/bug-config.json
+++ b/projects/log_collector/demo-app/bug-config.json
@@ -1,7 +1,7 @@
 {
   "bugs": {
     "PRODUCT_STOCK_ZERO_NPE": {
-      "enabled": true,
+      "enabled": false,
       "description": "GET /api/robots/:sku で stock=0 の商品を見ると related_products を undefined で map しようとして TypeError",
       "affects": "src/routes/products.js#getProduct",
       "trigger": "SKU RBT-DOG-02 (stock=0) の詳細ページを開く",

--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
-const { isEnabled } = require('../lib/bug-switch');
 const { logServiceCall, logServiceError } = require('../middleware/logger');
 
 const router = express.Router();
@@ -27,12 +26,7 @@ router.get('/:sku', (req, res, next) => {
 
     logServiceCall(req, 'inventory-service', { action: 'get_related_products', sku: robot.sku });
 
-    let relatedList;
-    if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
-    } else {
-      relatedList = robot.related || [];
-    }
+    const relatedList = robot.related || [];
 
     const related = relatedList.map(sku => {
       const r = robots.find(x => x.sku === sku);


### PR DESCRIPTION
## 概要
Issue #22 自動改修デモ対応。INC001 (TrackID: 9AD1511) に対する修正PRです。

## 一次解析結果
GET /api/robots/RBT-DOG-02 がHTTP 500を返却。アプリ層(app.log)・サービス層(service.log, inventory-service)ともに `TypeError: Cannot read properties of undefined (reading 'map')` がTrackID:9AD1511で記録され、products.js:37で例外発生。

原因: `src/routes/products.js` 内で stock===0 かつ機能フラグ `PRODUCT_STOCK_ZERO_NPE` (bug-config.json) が有効な場合、`relatedList` に `robot.out_of_stock_alternatives` を代入するが、`data/robots.json` のRBT-DOG-02にはこのフィールドが定義されておらず undefined となり、続く `.map()` 呼び出しで例外が発生していた。

## 改修内容
- `src/routes/products.js`: `PRODUCT_STOCK_ZERO_NPE` フラグによる分岐を廃止し、常に `robot.related || []` を安全に参照するよう統一。未使用となった `isEnabled` の import も削除。
- `bug-config.json`: `PRODUCT_STOCK_ZERO_NPE.enabled` を `false` に変更(整合性のため)。

## 承認者
三井

## TrackID
9AD1511

---
🤖 Generated with Claude Code
