### PR TITLE
fix(demo-app): stock=0時のrelated_products参照でTypeError修正 (INC001, TrackID:90AD4DC)

### DIFF
--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -27,11 +27,9 @@ router.get('/:sku', (req, res, next) => {
 
     logServiceCall(req, 'inventory-service', { action: 'get_related_products', sku: robot.sku });
 
-    let relatedList;
+    let relatedList = robot.related || [];
     if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
-    } else {
-      relatedList = robot.related || [];
+      relatedList = robot.out_of_stock_alternatives || relatedList;
     }
 
     const related = relatedList.map(sku => {


### PR DESCRIPTION
## 概要
Issue #22 自動改修デモ: INC001 (TrackID: 90AD4DC) の修正。

`GET /api/robots/RBT-DOG-02` で TypeError (undefined.map) が発生し500エラーとなる不具合を修正。

## 一次解析結果
【症状】GET /api/robots/RBT-DOG-02 が HTTP 500 を返却。TrackID:90AD4DCでアプリ層(app.log)・サービス層(service.log, inventory-service)双方に TypeError: Cannot read properties of undefined (reading 'map') が記録されている。発生箇所は src/routes/products.js:37 の related配列に対する.map()呼び出し。

【原因仮説】(信頼度:高) products.js内で stock===0 かつ bug-switch の PRODUCT_STOCK_ZERO_NPE フラグが有効な場合、relatedListに robot.out_of_stock_alternatives を代入するが、data/robots.jsonのRBT-DOG-02にはout_of_stock_alternativesフィールドが定義されておらずundefinedとなる。そのままrelatedList.map()を呼び出しTypeErrorが発生。

【影響範囲】stock=0の商品詳細取得API (/api/robots/:sku) 全般に波及しうる。

## 改修内容
`projects/log_collector/demo-app/src/routes/products.js` にて、`out_of_stock_alternatives` が未定義の場合でも常に配列を保証するようフォールバックを追加。

```diff
-    let relatedList;
-    if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
-    } else {
-      relatedList = robot.related || [];
-    }
+    let relatedList = robot.related || [];
+    if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
+      relatedList = robot.out_of_stock_alternatives || relatedList;
+    }
```

## 承認者
hoge

## TrackID
90AD4DC (INC001)

## テスト
`demo-app` に npm test スクリプトが未定義のためスキップ (repair_plan記載の追加テストケースは別途実装推奨)。

---
🤖 Generated with Claude Code
