### PR TITLE
fix(demo-app): stock=0商品のrelated_products TypeError修正 (INC001, TrackID:3DACBFB)

### DIFF
--- a/projects/log_collector/demo-app/bug-config.json
+++ b/projects/log_collector/demo-app/bug-config.json
@@ -1,7 +1,7 @@
 {
   "bugs": {
     "PRODUCT_STOCK_ZERO_NPE": {
-      "enabled": true,
+      "enabled": false,
       "description": "GET /api/robots/:sku で stock=0 の商品を見ると related_products を undefined で map しようとして TypeError",
       "affects": "src/routes/products.js#getProduct",
       "trigger": "SKU RBT-DOG-02 (stock=0) の詳細ページを開く",

--- a/projects/log_collector/demo-app/src/routes/products.js
+++ b/projects/log_collector/demo-app/src/routes/products.js
@@ -27,12 +27,7 @@ router.get('/:sku', (req, res, next) => {
 
     logServiceCall(req, 'inventory-service', { action: 'get_related_products', sku: robot.sku });
 
-    let relatedList;
-    if (robot.stock === 0 && isEnabled('PRODUCT_STOCK_ZERO_NPE')) {
-      relatedList = robot.out_of_stock_alternatives;
-    } else {
-      relatedList = robot.related || [];
-    }
+    const relatedList = robot.related || [];
 
     const related = relatedList.map(sku => {
       const r = robots.find(x => x.sku === sku);


### PR DESCRIPTION
## 概要
Issue #22 自動改修デモ対応。INC001 (TrackID: 3DACBFB) の自動修正PRです。

`GET /api/robots/RBT-DOG-02` (stock=0商品) 参照時に `TypeError: Cannot read properties of undefined (reading 'map')` が発生し 500 エラーとなっていた不具合を修正しました。

## 一次解析結果
GET /api/robots/RBT-DOG-02 が HTTP 500 を返却。app.log(client)とservice.log(inventory-service)の両ログにTrackID:3DACBFBで紐づくTypeError: Cannot read properties of undefined (reading 'map') が記録されている。発生箇所は src/routes/products.js:37。

原因: products.js の GET /:sku ハンドラで、stock===0 かつ機能フラグ `PRODUCT_STOCK_ZERO_NPE` が有効な場合、related_products の元データとして `robot.out_of_stock_alternatives` を参照するが、`data/robots.json` 内の RBT-DOG-02 (stock:0) にはこのフィールドが定義されておらず undefined となり、`.map()` でTypeErrorが発生していた。

## 改修内容
- `src/routes/products.js`: stock===0 分岐を削除し、常に `robot.related || []` を使用するように修正
- `bug-config.json`: `PRODUCT_STOCK_ZERO_NPE.enabled` を `true` → `false` に変更

## 承認者
hoge

## TrackID
3DACBFB (INC001)

🤖 Generated with Claude Code
